### PR TITLE
Add openstack-clients to access and controller

### DIFF
--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -2,4 +2,5 @@ class role::access {
   include ::profile::baseconfig
   include ::mysql::client
   include ::profile::sssd::accessvm
+  include ::profile::openstack::clients
 }

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -12,6 +12,7 @@ class role::controller {
   #include ::profile::corosync
   
   # Openstack controller
+  include ::profile::openstack::clients
   include ::profile::openstack::keystone
   include ::profile::openstack::glance
   include ::profile::openstack::novacontroller


### PR DESCRIPTION
As the openstack-clients are moved from profile::baseconfig to profile::openstack::clients from v.0.5.1, we now need to add profile::openstack::clients to the relevant roles.