### PR TITLE
Munin-cgi, user-administration, tools and cleaning

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -2,5 +2,4 @@ class role::base {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
   include ::profile::users
-  include ::profile::norpf
 }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,5 +1,5 @@
 class role::base {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
 }

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -9,6 +9,7 @@ class role::compute {
   # Openstack compute
   include ::profile::openstack::neutronagent
   include ::profile::openstack::novacompute
+  include ::profile::munin::plugin::compute
 
   # Monitoring
   #include ::profile::monitoring::logstashforwarder

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -1,7 +1,7 @@
 class role::compute {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
 
   # Storage
   include ::profile::ceph::client
@@ -9,7 +9,6 @@ class role::compute {
   # Openstack compute
   include ::profile::openstack::neutronagent
   include ::profile::openstack::novacompute
-  include ::profile::users::nova
 
   # Monitoring
   #include ::profile::monitoring::logstashforwarder

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -2,7 +2,6 @@ class role::compute {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
   include ::profile::users
-  include ::profile::norpf
 
   # Storage
   include ::profile::ceph::client

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -8,7 +8,6 @@ class role::controller {
   include ::profile::keepalived
   include ::profile::mysqlcluster
   include ::profile::rabbitmq
-  include ::profile::norpf
   #include ::profile::corosync
   
   # Openstack controller

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -1,7 +1,7 @@
 class role::controller {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
   
   # Include base services needed by openstack
   include ::profile::services::memcache

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -4,11 +4,9 @@ class role::controller {
   include ::profile::users
   
   # Include base services needed by openstack
-  include ::profile::memcache
-  include ::profile::keepalived
-  include ::profile::mysqlcluster
+  include ::profile::services::memcache
+  include ::profile::mysql::cluster
   include ::profile::rabbitmq
-  #include ::profile::corosync
   
   # Openstack controller
   include ::profile::openstack::clients

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -6,7 +6,6 @@ class role::controller {
   # Include base services needed by openstack
   include ::profile::services::memcache
   include ::profile::mysql::cluster
-  include ::profile::rabbitmq
   
   # Openstack controller
   include ::profile::openstack::clients

--- a/manifests/controller/step1.pp
+++ b/manifests/controller/step1.pp
@@ -5,5 +5,4 @@ class role::controller::step1 {
   
   # Include base services needed by openstack
   include ::profile::services::memcache
-  include ::profile::rabbitmq
 }

--- a/manifests/controller/step1.pp
+++ b/manifests/controller/step1.pp
@@ -4,7 +4,6 @@ class role::controller::step1 {
   include ::profile::users
   
   # Include base services needed by openstack
-  include ::profile::memcache
-  include ::profile::keepalived
+  include ::profile::services::memcache
   include ::profile::rabbitmq
 }

--- a/manifests/controller/step1.pp
+++ b/manifests/controller/step1.pp
@@ -7,5 +7,4 @@ class role::controller::step1 {
   include ::profile::memcache
   include ::profile::keepalived
   include ::profile::rabbitmq
-  include ::profile::norpf
 }

--- a/manifests/controller/step1.pp
+++ b/manifests/controller/step1.pp
@@ -1,7 +1,7 @@
 class role::controller::step1 {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
   
   # Include base services needed by openstack
   include ::profile::services::memcache

--- a/manifests/controller/step2.pp
+++ b/manifests/controller/step2.pp
@@ -6,5 +6,4 @@ class role::controller::step2 {
   # Include base services needed by openstack
   include ::profile::services::memcache
   include ::profile::mysql::cluster
-  include ::profile::rabbitmq
 }

--- a/manifests/controller/step2.pp
+++ b/manifests/controller/step2.pp
@@ -1,7 +1,7 @@
 class role::controller::step2 {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
   
   # Include base services needed by openstack
   include ::profile::services::memcache

--- a/manifests/controller/step2.pp
+++ b/manifests/controller/step2.pp
@@ -8,5 +8,4 @@ class role::controller::step2 {
   include ::profile::keepalived
   include ::profile::mysqlcluster
   include ::profile::rabbitmq
-  include ::profile::norpf
 }

--- a/manifests/controller/step2.pp
+++ b/manifests/controller/step2.pp
@@ -4,8 +4,7 @@ class role::controller::step2 {
   include ::profile::users
   
   # Include base services needed by openstack
-  include ::profile::memcache
-  include ::profile::keepalived
-  include ::profile::mysqlcluster
+  include ::profile::services::memcache
+  include ::profile::mysql::cluster
   include ::profile::rabbitmq
 }

--- a/manifests/controller/step3.pp
+++ b/manifests/controller/step3.pp
@@ -6,7 +6,6 @@ class role::controller::step3 {
   # Include base services needed by openstack
   include ::profile::services::memcache
   include ::profile::mysql::cluster
-  include ::profile::rabbitmq
 
   # Ceph
   include ::profile::ceph::monitor

--- a/manifests/controller/step3.pp
+++ b/manifests/controller/step3.pp
@@ -1,7 +1,7 @@
 class role::controller::step3 {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
   
   # Include base services needed by openstack
   include ::profile::services::memcache

--- a/manifests/controller/step3.pp
+++ b/manifests/controller/step3.pp
@@ -8,7 +8,6 @@ class role::controller::step3 {
   include ::profile::keepalived
   include ::profile::mysqlcluster
   include ::profile::rabbitmq
-  include ::profile::norpf
 
   # Ceph
   include ::profile::ceph::monitor

--- a/manifests/controller/step3.pp
+++ b/manifests/controller/step3.pp
@@ -4,9 +4,8 @@ class role::controller::step3 {
   include ::profile::users
   
   # Include base services needed by openstack
-  include ::profile::memcache
-  include ::profile::keepalived
-  include ::profile::mysqlcluster
+  include ::profile::services::memcache
+  include ::profile::mysql::cluster
   include ::profile::rabbitmq
 
   # Ceph

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -12,4 +12,5 @@ class role::manager {
   include ::profile::managerbackups
   include ::profile::services::puppetdb
   include ::profile::infrastructure::tftpserver
+  include ::profile::baseconfig::sudo::foreman
 }

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -11,5 +11,5 @@ class role::manager {
   # Manager-specific
   include ::profile::managerbackups
   include ::profile::puppetdb
-  include ::profile::tftpserver
+  include ::profile::infrastructure::tftpserver
 }

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -10,6 +10,6 @@ class role::manager {
 
   # Manager-specific
   include ::profile::managerbackups
-  include ::profile::puppetdb
+  include ::profile::services::puppetdb
   include ::profile::infrastructure::tftpserver
 }

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -2,7 +2,6 @@ class role::manager {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
   include ::profile::users
-  include ::profile::norpf
 
   # Monitoring
   #include ::profile::monitoring::logstashforwarder

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -1,7 +1,7 @@
 class role::manager {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
 
   # Monitoring
   #include ::profile::monitoring::logstashforwarder

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -5,11 +5,6 @@ class role::monitor {
   include ::profile::norpf
 
   # Monitoring
-  include ::profile::monitoring::apache
-  #include ::profile::monitoring::elk
-  #include ::profile::monitoring::reverseproxy
-  #include ::profile::monitoring::logstashforwarder
-  #include ::profile::monitoring::icingaserver
   include ::profile::munin::master
   include ::profile::munin::node
 }

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -2,7 +2,6 @@ class role::monitor {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
   include ::profile::users
-  include ::profile::norpf
 
   # Monitoring
   include ::profile::munin::master

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -1,7 +1,7 @@
 class role::monitor {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
 
   # Monitoring
   include ::profile::munin::master

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -1,7 +1,7 @@
 class role::storage {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
-  include ::profile::users
+  include ::profile::baseconfig::users
 
   # Storage
   include ::profile::ceph::osd

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -2,7 +2,6 @@ class role::storage {
   # Baseconfiguration. Should be on all hosts.
   include ::profile::baseconfig
   include ::profile::users
-  include ::profile::norpf
 
   # Storage
   include ::profile::ceph::osd


### PR DESCRIPTION
This merge merges in quite a few changes:
 - Munin now lives in its own vhost; and graphing is done on demand trough cgi. This allows us to navigate in the graph.
 - A small hack is implemented to prevent the controllers from loosing their gateway. (pinging an external host trough cron)
 - Our small script tools are now distributed by puppet.
 - Users are now configured from hiera. BE AWARE! 
 - Quite a lot of code cleaning.