### PR TITLE
Standalone-roles

### DIFF
--- a/manifests/management.pp
+++ b/manifests/management.pp
@@ -1,0 +1,9 @@
+# Installs a management-utilities server. Contains DHCP/TFTP/Shiftleader.
+class role::management {
+  include ::profile::baseconfig
+  include ::profile::baseconfig::users
+
+  include ::profile::services::dashboard
+  include ::profile::services::dhcp
+  include ::profile::services::tftp
+}

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -1,11 +1,4 @@
-# This role installs a mysql server
+# Transitional class left for compatibility. Use ::role::mysql::cluster instead.
 class role::mysql {
-  include ::profile::baseconfig
-  include ::profile::baseconfig::users
-
-  include ::profile::services::mysql
-  include ::profile::services::dashboard::mysql
-
-  # Create various databases for us
-  include ::ntnuopenstack::databases
+  include ::role::mysql::cluster
 }

--- a/manifests/mysql/cluster.pp
+++ b/manifests/mysql/cluster.pp
@@ -1,0 +1,11 @@
+# This role installs a mysql server joining a galera cluster
+class role::mysql::cluster {
+  include ::profile::baseconfig
+  include ::profile::baseconfig::users
+
+  include ::profile::services::mysql::cluster
+  include ::profile::services::dashboard::mysql
+
+  # Create various databases for us
+  include ::ntnuopenstack::databases
+}

--- a/manifests/mysql/standalone.pp
+++ b/manifests/mysql/standalone.pp
@@ -1,0 +1,11 @@
+# This role installs a stand-alone mysql server
+class role::mysql::standalone {
+  include ::profile::baseconfig
+  include ::profile::baseconfig::users
+
+  include ::profile::services::mysql::standalone
+  include ::profile::services::dashboard::mysql
+
+  # Create various databases for us
+  include ::ntnuopenstack::databases
+}

--- a/manifests/puppet/aio.pp
+++ b/manifests/puppet/aio.pp
@@ -1,0 +1,8 @@
+# This role installs a puppetserver and puppetdb on the same host.
+class role::puppet::server {
+  include ::profile::baseconfig
+  include ::profile::baseconfig::users
+
+  include ::profile::services::puppet::db
+  include ::profile::services::puppet::aio
+}

--- a/manifests/puppet/aio.pp
+++ b/manifests/puppet/aio.pp
@@ -1,5 +1,5 @@
 # This role installs a puppetserver and puppetdb on the same host.
-class role::puppet::server {
+class role::puppet::aio {
   include ::profile::baseconfig
   include ::profile::baseconfig::users
 


### PR DESCRIPTION
This release brings in a couple of new roles intended for smaller installations where clusteres is not nessecarily desired:
 - role::management: Dashboard combined with the DHCP/TFTP role.
 - role::mysql::cluster: The new role for our mysql-clusters.
 - role::mysql::standalone: A stand-alone mysql server.
 - role::puppet::aio: An all-in-one puppet. CA/server/DB.