### PR TITLE
Add role::openstack::neutron::bgp::multi

### DIFF
--- a/manifests/openstack/neutron/bgp/multi.pp
+++ b/manifests/openstack/neutron/bgp/multi.pp
@@ -1,0 +1,18 @@
+# This class installs a neutron bgp agent node which can run multiple BGP
+# agents. 
+class role::openstack::neutron::bgp::multi {
+  include ::profile::baseconfig
+  include ::profile::baseconfig::users
+  $regionless = lookup('profile::region::missing::ok', {
+    'default_value' => false,
+    'value_type'    => Boolean,
+  })
+
+  if($regionless or ($::facts['ntnu'] and $::facts['ntnu']['region'])) {
+    include ::ntnuopenstack::neutron::bgp::multi
+  } else {
+    notify { 'Base-Only':
+      message => 'Only role::base applied due to missing region fact',
+    }
+  }
+}


### PR DESCRIPTION
Adding a role for running multiple BGP speakers on the same hosts.